### PR TITLE
Check based on a regexp matching only hexadecimal

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@
 var Joi = require('joi');
 
 module.exports = function objectId() {
-  return Joi.string().alphanum().length(24);
-}
+  return Joi.string().regex(/^[0-9a-fA-F]{24}$/);
+};

--- a/test.js
+++ b/test.js
@@ -4,12 +4,12 @@ var Joi = require('joi');
 var oid = require('./');
 
 describe('joi-objectid', function() {
-  it('requires an alphnum string of 24 chars', function(done) {
+  it('requires an hexadecimal string of 24 chars', function(done) {
     var tests = [
-      { val: '$sdf56789012345678901234', pass: false }
-    , { val: ' sdf56789012345678901234', pass: false }
-    , { val: 'asdf5678901234567890123', pass: false }
-    , { val: 'asdf56789012345678901234', pass: true }
+      { val: '$bcd56789012345678901234', pass: false }
+    , { val: ' bcd56789012345678901234', pass: false }
+    , { val: 'abcd5678901234567890123', pass: false }
+    , { val: 'abcd56789012345678901234', pass: true }
     , { val: 123456789012345678901234, pass: false }
     , { val: { length: 24 } , pass: false }
     ]
@@ -19,7 +19,7 @@ describe('joi-objectid', function() {
     tests.forEach(function(test) {
       var res = Joi.validate({ val: test.val }, schema);
       assert(test.pass === ! res.error, res.error);
-    })
+    });
 
     done();
   });


### PR DESCRIPTION
Comparing strings based on this regexp should be more accurate than current implementation.
