### PR TITLE
breaking; now exports a factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It's used just like you'd use any other `Joi` type.
 
 ```js
 var Joi = require('joi');
-Joi.objectId = require('joi-objectid');
+Joi.objectId = require('joi-objectid')(Joi);
 
 var schema = {
   id: Joi.objectId()
@@ -34,7 +34,7 @@ npm install joi-objectid --save
 
 #### running tests
 
-- `make test` runs tests
+- `make test`
 
 ## Sponsored by
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
+'use strict';
 
-var Joi = require('joi');
+var assert = require('assert');
 
-module.exports = function objectId() {
-  return Joi.string().regex(/^[0-9a-fA-F]{24}$/);
+module.exports = function joiObjectId(Joi) {
+  assert(Joi && Joi.isJoi, 'you must pass Joi as an argument');
+
+  return function objectId() {
+    return Joi.string().regex(/^[0-9a-fA-F]{24}$/);
+  };
 };

--- a/test.js
+++ b/test.js
@@ -1,10 +1,29 @@
+'use strict';
 
 var assert = require('assert');
 var Joi = require('joi');
-var oid = require('./');
+var joiObjectId = require('./');
 
 describe('joi-objectid', function() {
+  it('exports a function', function(done) {
+    assert.equal('function', typeof joiObjectId);
+    done();
+  });
+
+  it('expects to receive a Joi module', function(done) {
+    assert.throws(joiObjectId, /must pass Joi/);
+    done();
+  });
+
+  it('returns a validator function', function(done) {
+    var fn = joiObjectId(Joi);
+    assert.equal('function', typeof fn);
+    done();
+  });
+
   it('requires an hexadecimal string of 24 chars', function(done) {
+    var oid = joiObjectId(Joi);
+
     var tests = [
       { val: '$bcd56789012345678901234', pass: false }
     , { val: ' bcd56789012345678901234', pass: false }


### PR DESCRIPTION
This change supports additional application structures eg when using a version of Joi in your application which was exported via an application dependency.

```
structure:

  app/
    node_modules/
      something_that_exports_joi

app.js:

  var Joi = require('something_that_exports_joi').Joi;
  Joi.objectId = require('joi-objectid')(Joi);
```