### PR TITLE
beautiful error messages.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 'use strict';
 
 var assert = require('assert');
+var defaultMessage = 'valid mongo id';
 
-module.exports = function joiObjectId(Joi) {
+module.exports = function joiObjectId(Joi, message) {
   assert(Joi && Joi.isJoi, 'you must pass Joi as an argument');
-
+  if (message == undefined) {
+    message = defaultMessage;
+  }
   return function objectId() {
-    return Joi.string().regex(/^[0-9a-fA-F]{24}$/);
+    return Joi.string().regex(/^[0-9a-fA-F]{24}$/, defaultMessage);
   };
 };


### PR DESCRIPTION
This will make appear a beautiful error message like `... fails to match the valid mongo id pattern` instead of `... fails to match /^[0-9a-fA-F]{24}$/ pattern`.
